### PR TITLE
fix: chrome debugging in VS Code (server detect) wasn't working due to an extra space after the colon

### DIFF
--- a/src/lib/run-dev.js
+++ b/src/lib/run-dev.js
@@ -179,7 +179,7 @@ async function runDev (runOptions, config, _inprocHookRunner) {
     if (serverPort !== serverPortToUse) {
       serveLogger.info(`Could not use server port ${serverPortToUse}, using port ${serverPort} instead`)
     }
-    serveLogger.info('server running on port : ', serverPort)
+    serveLogger.info(`server running on port : ${serverPort}`)
   })
 
   let frontendUrl

--- a/test/lib/run-dev.test.js
+++ b/test/lib/run-dev.test.js
@@ -772,7 +772,7 @@ describe('runDev', () => {
       expect(Object.keys(actionUrls).length).toBeGreaterThan(0)
       // this next test is important: this is how VS Code debug launch configuration reads the port, from the log
       // see: https://github.com/adobe/generator-aio-app/blob/master/test/__fixtures__/add-vscode-config/launch.json
-      expect(mockLogger.info).toHaveBeenCalledWith('server running on port : ', SERVER_DEFAULT_PORT)
+      expect(mockLogger.info).toHaveBeenCalledWith(`server running on port : ${SERVER_DEFAULT_PORT}`)
     }
 
     // 1. run options *not* https


### PR DESCRIPTION
## How Has This Been Tested?

- npm test
- vs code chrome debugging test 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
