### PR TITLE
fix: add syntax error action deploy handling (e2e testproject)

### DIFF
--- a/e2e/test-project/package.json
+++ b/e2e/test-project/package.json
@@ -3,28 +3,29 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "@adobe/generator-app-excshell": "^1.0.1",
     "@adobe/aio-sdk": "^5",
-    "node-fetch": "^2.6.0",
+    "@adobe/exc-app": "^1.3.0",
+    "@adobe/generator-app-excshell": "^1.0.1",
+    "@adobe/react-spectrum": "^3.4.0",
+    "@spectrum-icons/workflow": "^3.2.0",
     "core-js": "^3.6.4",
+    "node-fetch": "^2.6.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-router-dom": "^5.2.0",
     "react-error-boundary": "^1.2.5",
-    "regenerator-runtime": "^0.13.5",
-    "@adobe/exc-app": "^1.3.0",
-    "@adobe/react-spectrum": "^3.4.0",
-    "@spectrum-icons/workflow": "^3.2.0"
+    "react-router-dom": "^5.2.0",
+    "regenerator-runtime": "^0.13.5"
   },
   "devDependencies": {
-    "eslint": "^8",
-    "eslint-plugin-jest": "^27.2.3",
-    "jest": "^29",
-    "@openwhisk/wskdebug": "^1.3.0",
     "@babel/core": "^7.8.7",
+    "@babel/plugin-transform-react-jsx": "^7.8.3",
     "@babel/polyfill": "^7.8.7",
     "@babel/preset-env": "^7.8.7",
-    "@babel/plugin-transform-react-jsx": "^7.8.3"
+    "@openwhisk/wskdebug": "^1.3.0",
+    "eslint": "^8",
+    "eslint-plugin-jest": "^27.2.3",
+    "file-loader": "^6.2.0",
+    "jest": "^29"
   },
   "scripts": {
     "test": "jest --passWithNoTests ./test",

--- a/e2e/test-project/src/dx-excshell-1/actions/syntaxidermist/index.js
+++ b/e2e/test-project/src/dx-excshell-1/actions/syntaxidermist/index.js
@@ -11,6 +11,6 @@ governing permissions and limitations under the License.
 */
 
 exports.main = function () {
-  // this error is expected, its what we are testing
+  // @ts-expect-error this error is expected, its what we are testing
   const colon = :
 }

--- a/e2e/test-project/src/dx-excshell-1/ext.config.yaml
+++ b/e2e/test-project/src/dx-excshell-1/ext.config.yaml
@@ -1,3 +1,5 @@
+hooks:
+  post-app-deploy: node src/dx-excshell-1/hooks/post-app-deploy.js
 operations:
   view:
     - type: web
@@ -74,7 +76,7 @@ runtimeManifest:
             LOG_LEVEL: debug
           annotations:
             final: true
-        syntaxError:
+        syntaxError: # for deploying to actual Runtime, modify hooks/post-app-deploy.js. Since webpack won't build a module with a syntax error
           function: actions/syntaxidermist/index.js
           web: 'yes'
           runtime: nodejs:18

--- a/e2e/test-project/src/dx-excshell-1/hooks/post-app-deploy.js
+++ b/e2e/test-project/src/dx-excshell-1/hooks/post-app-deploy.js
@@ -1,0 +1,21 @@
+const { execFile } = require('node:child_process')
+
+console.log('running post-app-deploy...')
+
+async function main () {
+  const cwd = process.cwd()
+  const command = 'aio'
+  const args = ['rt', 'action', 'update', 'dx-excshell-1/syntaxError', `${cwd}/src/dx-excshell-1/actions/syntaxidermist/index.js`]
+
+  console.log(`Running '${[command, ...args].join(' ')}'`)
+  await execFile(command, args, (error, stdout, stderr) => {
+    if (error) {
+      throw error
+    }
+    stdout && console.log(stdout)
+    stderr && console.log(stderr)
+  })
+}
+
+main()
+  .catch(console.error)

--- a/e2e/test-project/webpack-config.js
+++ b/e2e/test-project/webpack-config.js
@@ -1,0 +1,19 @@
+
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /syntaxidermist\/index.js$/,
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              name: '__index.js',
+              emitFile: true
+            }
+          },
+        ],
+      },
+    ],
+  },
+}


### PR DESCRIPTION
related: #71 

## Description

There is currently an issue when deploying the e2e/testproject. Since we are deploying an action with a syntax error, webpack doesn't like this and will error out. We solve this by ignoring this by using a file-loader that we will ignore the output for now. Ideally we have a loader that doesn't do any compilation, but we are working with our `aio-lib-runtime` webpack functionality in this fix. 

We solve this by our `post-app-deploy` hook, which updates the relevant action by calling the command `aio rt action update` with the unaltered source file.

This doesn't affect the dev plugin loading, since we directly load the action file entry point.

## How Has This Been Tested?

For `e2e/test-project`:
- aio app deploy --no-publish
- `curl` the affected action url to test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
