### PR TITLE
feat: ACNA-3097 - support web:raw

### DIFF
--- a/e2e/e2e.js
+++ b/e2e/e2e.js
@@ -180,7 +180,7 @@ describe('http api tests', () => {
     expect(responseJson.params).toMatchObject({ [key]: value })
   })
 
-  test('non-raw: post unknown content-type', async () => {
+  test('non-raw: post text/plain content-type, with body', async () => {
     // any other content-type, the body will be base64 encoded into __ow_body
     const key = 'some_key'
     const value = 'some_value'
@@ -193,7 +193,7 @@ describe('http api tests', () => {
     const response = await fetch(url, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/x-some-thing'
+        'Content-Type': 'text/plain'
       },
       body,
       agent: HTTPS_AGENT
@@ -202,16 +202,16 @@ describe('http api tests', () => {
     expect(response.ok).toBeTruthy()
     expect(response.status).toEqual(200)
     const responseJson = await response.json()
-    expect(responseJson.params).toMatchObject({ __ow_body: Buffer.from(body).toString('base64') })
+    expect(responseJson.params).toMatchObject({ __ow_body: body })
   })
 
-  test('non-raw: post unknown content-type, no body', async () => {
+  test('non-raw: post text/plain content-type, no body', async () => {
     const url = createApiUrl({ actionName: 'post-data' })
 
     const response = await fetch(url, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/x-some-thing'
+        'Content-Type': 'text/plain'
       },
       agent: HTTPS_AGENT
     })
@@ -287,7 +287,7 @@ describe('http api tests', () => {
     expect(responseJson.params).toMatchObject({ __ow_body: body })
   })
 
-  test('raw: post unknown content-type', async () => {
+  test('raw: post text/plain content-type', async () => {
     // NOTE: for any other content-type, raw will always set __ow_body (base64 encoded)
     const url = createApiUrl({ actionName: 'post-raw-data' })
     const body = '99 luftballons'
@@ -295,7 +295,7 @@ describe('http api tests', () => {
     const response = await fetch(url, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/x-foo-bar'
+        'Content-Type': 'text/plain'
       },
       body,
       agent: HTTPS_AGENT
@@ -304,7 +304,7 @@ describe('http api tests', () => {
     expect(response.ok).toBeTruthy()
     expect(response.status).toEqual(200)
     const responseJson = await response.json()
-    expect(responseJson.params).toMatchObject({ __ow_body: Buffer.from(body).toString('base64') })
+    expect(responseJson.params).toMatchObject({ __ow_body: body })
   })
 
   test('front end is available (200)', async () => {

--- a/e2e/e2e.js
+++ b/e2e/e2e.js
@@ -133,6 +133,26 @@ describe('http api tests', () => {
     }
   })
 
+  test('non-raw: post multipart/form-data content-type', async () => {
+    // NOTE: for this content-type, it will always set __ow_body (base64 encoded)
+    const url = createApiUrl({ actionName: 'post-data' })
+    const body = 'hey jude don\'t carry the world upon your shoulders'
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'multipart/form-data'
+      },
+      body,
+      agent: HTTPS_AGENT
+    })
+
+    expect(response.ok).toBeTruthy()
+    expect(response.status).toEqual(200)
+    const responseJson = await response.json()
+    expect(responseJson.params).toMatchObject({ __ow_body: Buffer.from(body).toString('base64') })
+  })
+
   test('non-raw: post application/x-www-form-urlencoded (should be promoted to params)', async () => {
     const key = 'some_key'
     const value = 'some_value'
@@ -288,7 +308,6 @@ describe('http api tests', () => {
   })
 
   test('raw: post text/plain content-type', async () => {
-    // NOTE: for any other content-type, raw will always set __ow_body (base64 encoded)
     const url = createApiUrl({ actionName: 'post-raw-data' })
     const body = '99 luftballons'
 

--- a/e2e/jest.e2e.setup.js
+++ b/e2e/jest.e2e.setup.js
@@ -20,5 +20,6 @@ beforeEach(() => {
   stderr.start()
   // change this if you need to see logs from stdout
   stdout.print = true
+  stderr.print = true
 })
 afterEach(() => { stdout.stop(); stderr.stop() })

--- a/e2e/test-project/src/dx-excshell-1/actions/post-raw-data/index.js
+++ b/e2e/test-project/src/dx-excshell-1/actions/post-raw-data/index.js
@@ -1,0 +1,10 @@
+async function main(params) {
+  const response = {
+    statusCode: 200,
+    body: {
+      params
+    }
+  }
+  return response
+}
+exports.main = main

--- a/e2e/test-project/src/dx-excshell-1/ext.config.yaml
+++ b/e2e/test-project/src/dx-excshell-1/ext.config.yaml
@@ -42,6 +42,14 @@ runtimeManifest:
             LOG_LEVEL: debug
           annotations:
             final: true
+        post-raw-data:
+          function: actions/post-raw-data/index.js
+          web: 'raw'
+          runtime: nodejs:18
+          inputs:
+            LOG_LEVEL: debug
+          annotations:
+            final: true
         noAdobeAuth:
           function: actions/simple/index.js
           web: 'yes'

--- a/e2e/test-project/src/dx-excshell-1/web-src/src/config.json
+++ b/e2e/test-project/src/dx-excshell-1/web-src/src/config.json
@@ -1,6 +1,7 @@
 {
   "dx-excshell-1/requireAdobeAuth": "https://localhost:9080/api/v1/web/dx-excshell-1/requireAdobeAuth",
   "dx-excshell-1/post-data": "https://localhost:9080/api/v1/web/dx-excshell-1/post-data",
+  "dx-excshell-1/post-raw-data": "https://localhost:9080/api/v1/web/dx-excshell-1/post-raw-data",
   "dx-excshell-1/noAdobeAuth": "https://localhost:9080/api/v1/web/dx-excshell-1/noAdobeAuth",
   "dx-excshell-1/squareNumber": "https://localhost:9080/api/v1/web/dx-excshell-1/squareNumber",
   "dx-excshell-1/addNumbers": "https://localhost:9080/api/v1/web/dx-excshell-1/addNumbers",

--- a/src/lib/app-helper.js
+++ b/src/lib/app-helper.js
@@ -115,6 +115,10 @@ function writeConfig (file, config) {
  * @returns {boolean} true if it's empty
  */
 function isEmptyObject (obj) {
+  if (typeof obj !== 'object') {
+    return false
+  }
+
   let name
   for (name in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, name)) {
@@ -132,7 +136,7 @@ function isEmptyObject (obj) {
  */
 function bodyTransformToRaw (body) {
   if (typeof body === 'string') {
-    return Buffer.from(body).toString('base64')
+    return body
   } else if (typeof body === 'object') {
     // body can be the empty object
     if (!isEmptyObject(body)) {

--- a/src/lib/app-helper.js
+++ b/src/lib/app-helper.js
@@ -106,7 +106,50 @@ function writeConfig (file, config) {
   fs.writeJSONSync(file, config, { spaces: 2 })
 }
 
+/**
+ * The fastest way to determine an empty object, since it short-circuits.
+ * (JSON.stringify is ten to 100 times slower objectively, and wasteful)
+ * https://stackoverflow.com/a/59787784
+ *
+ * @param {object} obj the object to test
+ * @returns {boolean} true if it's empty
+ */
+function isEmptyObject (obj) {
+  let name
+  for (name in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, name)) {
+      return false
+    }
+  }
+  return true
+}
+
+/**
+ * Transforms the request body to the expected raw format.
+ *
+ * @param {string | object} body the request body
+ * @returns {string} expected raw format (base64 or empty string)
+ */
+function bodyTransformToRaw (body) {
+  if (typeof body === 'string') {
+    return Buffer.from(body).toString('base64')
+  } else if (typeof body === 'object') {
+    // body can be the empty object
+    if (!isEmptyObject(body)) {
+      if (Buffer.isBuffer(body)) {
+        return body.toString('base64')
+      } else {
+        return Buffer.from(JSON.stringify(body)).toString('base64')
+      }
+    }
+  }
+
+  return ''
+}
+
 module.exports = {
+  bodyTransformToRaw,
+  isEmptyObject,
   runInProcess,
   runScript,
   writeConfig

--- a/src/lib/app-helper.js
+++ b/src/lib/app-helper.js
@@ -142,7 +142,7 @@ function bodyTransformToRaw (body) {
     if (!isEmptyObject(body)) {
       if (Buffer.isBuffer(body)) {
         return body.toString('base64')
-      } else {
+      } else { // only choice, must be JSON
         return Buffer.from(JSON.stringify(body)).toString('base64')
       }
     }

--- a/src/lib/run-dev.js
+++ b/src/lib/run-dev.js
@@ -473,11 +473,16 @@ async function serveWebAction (req, res, actionConfig) {
   }
 
   const actionLogger = coreLogger(`serveWebAction ${contextItemName}`, { level: process.env.LOG_LEVEL, provider: 'winston' })
+  let contextItemParams
 
-  const contextItemParams = createActionParametersFromRequest({ req, contextItem, actionInputs: action?.inputs })
-  contextItemParams.__ow_path = owPath
-
-  actionLogger.debug('contextItemParams =', contextItemParams)
+  try {
+    contextItemParams = createActionParametersFromRequest({ req, contextItem, actionInputs: action?.inputs })
+    contextItemParams.__ow_path = owPath
+    actionLogger.debug('contextItemParams =', contextItemParams)
+  } catch (e) {
+    const actionResponse = { statusCode: 400, body: { error: e.message } }
+    return httpStatusResponse({ actionResponse, res, logger: actionLogger })
+  }
 
   const actionRequestContext = {
     packageName,

--- a/src/lib/run-dev.js
+++ b/src/lib/run-dev.js
@@ -161,10 +161,15 @@ async function runDev (runOptions, config, _inprocHookRunner) {
   }
 
   const app = express()
-  app.use(express.text({ type: 'text/plain' }))
-  app.use(express.json({ strict: false }))
-  app.use(express.urlencoded())
-  app.use(express.raw({ type: RAW_CONTENT_TYPES }))
+
+  const middlewareOptions = {
+    inflate: false, // the same behavior in the cloud
+    limit: '1MB' // the same limits in the cloud
+  }
+  app.use(express.text({ ...middlewareOptions, type: 'text/plain' }))
+  app.use(express.json({ ...middlewareOptions, strict: false }))
+  app.use(express.urlencoded(middlewareOptions))
+  app.use(express.raw({ ...middlewareOptions, type: RAW_CONTENT_TYPES }))
 
   if (hasFrontend) {
     app.use(connectLiveReload())

--- a/src/lib/run-dev.js
+++ b/src/lib/run-dev.js
@@ -22,7 +22,6 @@ const getPort = require('get-port')
 const rtLib = require('@adobe/aio-lib-runtime')
 const coreLogger = require('@adobe/aio-lib-core-logging')
 const { getReasonPhrase } = require('http-status-codes')
-const { Buffer } = require('node:buffer')
 
 const utils = require('./app-helper')
 const { SERVER_DEFAULT_PORT, BUNDLER_DEFAULT_PORT, DEV_API_PREFIX, DEV_API_WEB_PREFIX, BUNDLE_OPTIONS, CHANGED_ASSETS_PRINT_LIMIT } = require('./constants')
@@ -562,8 +561,6 @@ function createActionParametersFromRequest ({ req, contextItem, actionInputs = {
     if (isRaw) {
       if (isFormData) {
         params.__ow_body = new URLSearchParams(req.body).toString() // convert json back to query string
-      } else if (isJson) {
-        params.__ow_body = Buffer.from(JSON.stringify(req.body)).toString('base64')
       } else {
         params.__ow_body = utils.bodyTransformToRaw(req.body)
       }

--- a/test/__mocks__/express.js
+++ b/test/__mocks__/express.js
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 
 const staticMocks = {
+  raw: jest.fn(),
   json: jest.fn(),
   urlencoded: jest.fn(),
   static: jest.fn()

--- a/test/__mocks__/express.js
+++ b/test/__mocks__/express.js
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 
 const staticMocks = {
+  text: jest.fn(),
   raw: jest.fn(),
   json: jest.fn(),
   urlencoded: jest.fn(),

--- a/test/lib/run-dev.test.js
+++ b/test/lib/run-dev.test.js
@@ -605,6 +605,39 @@ describe('serveWebAction', () => {
     expect(mockStatus).toHaveBeenCalledWith(200)
   })
 
+  test('action found, is raw web action (unsupported content-type)', async () => {
+    const mimeType = 'application/x-foo-bar'
+    const mockStatus = jest.fn()
+    const mockSend = jest.fn()
+    const is = (_type) => _type === mimeType
+
+    const res = createRes({ mockStatus, mockSend })
+    const req = createReq({
+      is,
+      body: 'some body',
+      url: 'foo/bar',
+      headers: {
+        'content-type': mimeType
+      }
+    })
+    const packageName = 'foo'
+
+    const actionConfig = {
+      [packageName]: {
+        actions: {
+          bar: {
+            function: fixturePath('actions/successReturnAction.js'),
+            web: 'raw'
+          }
+        }
+      }
+    }
+
+    await serveWebAction(req, res, actionConfig)
+    expect(mockSend).toHaveBeenCalledTimes(1)
+    expect(mockStatus).toHaveBeenCalledWith(400)
+  })
+
   test('action not found, is sequence', async () => {
     const mockStatus = jest.fn()
     const mockSend = jest.fn()


### PR DESCRIPTION
fixes #79 

## Description

The POST behavior below has been verified on adobeioruntime.net, and the dev server matches the behavior.
This has been verified by the e2e tests.

There is no spec, just [example docs](https://github.com/apache/openwhisk/blob/master/docs/webactions.md#http-context), and the behavior is specified from the docs: `The __ow_body property is present either when handling "raw" HTTP requests, or when the HTTP request entity is not a JSON object or form data`

Note the quirk in the table for `application/x-www-form-urlencoded, raw`.

| content-type                                        | non-raw                          | raw                                                 |
|-------------------------------------|------------------------|---------------------------------|
| application/json                                    | promoted to params     | __ow_body base64 (stringified) |
| application/x-www-form-urlencoded | promoted to params     | __ow_body set to query string   |
| multipart/form-data                              | __ow_body base64       | __ow_body base64                    |
| text/plain                                                | __ow_body set to value | __ow_body set to value            |

## How Has This Been Tested?

- npm test
- npm run e2e (local)
- npm run e2e (production)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
