### PR TITLE
fix: add SERVER_HOST environment variable override

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ DESCRIPTION
 _See code: [src/commands/app/dev/index.js](https://github.com/adobe/aio-cli-plugin-app-dev/blob/1.0.1/src/commands/app/dev/index.js)_
 <!-- commandsstop -->
 
+## Overriding the hostname and port
+
+By default the hostname will be `localhost` and the default port is `9080`. You can override these values by setting these environment variables:
+
+1. `SERVER_HOST`
+2. `SERVER_DEFAULT_PORT`
+
+The command will try to use the default port, if it is not available it will find an open port to use instead.
+
 ## Contributing
 
 Contributions are welcomed! Read the [Contributing Guide](CONTRIBUTING.md) for more information.

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 // overridable in the env
 const {
   CHANGED_ASSETS_PRINT_LIMIT = 5,
+  SERVER_HOST = 'localhost',
   SERVER_DEFAULT_PORT = 9080,
   BUNDLER_DEFAULT_PORT = 9090,
   DEV_KEYS_DIR = 'dist/dev-keys',
@@ -27,6 +28,7 @@ const BUNDLE_OPTIONS = {
 }
 
 module.exports = {
+  SERVER_HOST,
   CHANGED_ASSETS_PRINT_LIMIT,
   SERVER_DEFAULT_PORT: parseInt(SERVER_DEFAULT_PORT, 10), // parse any env override
   BUNDLER_DEFAULT_PORT: parseInt(BUNDLER_DEFAULT_PORT, 10), // parse any env override

--- a/src/lib/run-dev.js
+++ b/src/lib/run-dev.js
@@ -24,7 +24,7 @@ const coreLogger = require('@adobe/aio-lib-core-logging')
 const { getReasonPhrase } = require('http-status-codes')
 
 const utils = require('./app-helper')
-const { SERVER_DEFAULT_PORT, BUNDLER_DEFAULT_PORT, DEV_API_PREFIX, DEV_API_WEB_PREFIX, BUNDLE_OPTIONS, CHANGED_ASSETS_PRINT_LIMIT } = require('./constants')
+const { SERVER_HOST, SERVER_DEFAULT_PORT, BUNDLER_DEFAULT_PORT, DEV_API_PREFIX, DEV_API_WEB_PREFIX, BUNDLE_OPTIONS, CHANGED_ASSETS_PRINT_LIMIT } = require('./constants')
 const RAW_CONTENT_TYPES = ['application/octet-stream', 'multipart/form-data']
 
 /* global Request, Response */
@@ -89,7 +89,7 @@ async function runDev (runOptions, config, _inprocHookRunner) {
     actionUrls = Object.entries(actionUrls).reduce((acc, [key, value]) => {
       const url = new URL(value)
       url.port = serverPort
-      url.hostname = 'localhost'
+      url.hostname = SERVER_HOST
       acc[key] = url.toString()
       return acc
     }, {})
@@ -181,7 +181,7 @@ async function runDev (runOptions, config, _inprocHookRunner) {
   app.all(`/${DEV_API_PREFIX}/*`, (req, res) => serveNonWebAction(req, res, actionConfig))
 
   const server = https.createServer(serverOptions, app)
-  server.listen(serverPort, () => {
+  server.listen(serverPort, SERVER_HOST, () => {
     if (serverPort !== serverPortToUse) {
       serveLogger.info(`Could not use server port ${serverPortToUse}, using port ${serverPort} instead`)
     }
@@ -190,7 +190,7 @@ async function runDev (runOptions, config, _inprocHookRunner) {
 
   let frontendUrl
   if (hasFrontend) {
-    frontendUrl = `${httpsSettings ? 'https:' : 'http:'}//localhost:${serverPort}`
+    frontendUrl = `${httpsSettings ? 'https:' : 'http:'}//${SERVER_HOST}:${serverPort}`
   }
 
   const serverCleanup = async () => {

--- a/test/lib/run-dev.test.js
+++ b/test/lib/run-dev.test.js
@@ -51,7 +51,7 @@ jest.mock('node:https', () => {
   return {
     createServer: jest.fn(() => {
       return {
-        listen: jest.fn((_, fn) => {
+        listen: jest.fn((_, __, fn) => {
           fn() // call right away, coverage
         }),
         close: jest.fn()


### PR DESCRIPTION
fixes #80

There is also the `SERVER_DEFAULT_PORT` env var is already supported

## How Has This Been Tested?

- `SERVER_HOST=my.example.domain aio app dev`
- try connecting to one of the urls displayed at that domain

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
