### PR TITLE
fix: improper use of readFile to read the generated public cert

### DIFF
--- a/src/commands/app/dev/index.js
+++ b/src/commands/app/dev/index.js
@@ -235,7 +235,7 @@ class Dev extends BaseCommand {
 
     // 2. store them globally in config
     const privateKey = (await fs.readFile(privateKeyPath, { encoding: 'utf8' }))
-    const publicCert = (await fs.readFile(pubCertPath), { encoding: 'utf8' })
+    const publicCert = (await fs.readFile(pubCertPath, { encoding: 'utf8' }))
     coreConfig.set(`${devKeysConfigKey}.privateKey`, privateKey)
     coreConfig.set(`${devKeysConfigKey}.publicCert`, publicCert)
 


### PR DESCRIPTION
## Description

Running `aio app dev` results in this error:
```
TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Object
    at writeFile (node:fs:2269:5)
    at go$writeFile (/Users/shazron/Documents/git/work/adobe/aio-cli-plugin-app-dev/node_modules/graceful-fs/graceful-fs.js:138:14)
    at Object.writeFile (/Users/shazron/Documents/git/work/adobe/aio-cli-plugin-app-dev/node_modules/graceful-fs/graceful-fs.js:135:12)
    at /Users/shazron/Documents/git/work/adobe/aio-cli-plugin-app-dev/node_modules/universalify/index.js:9:12
    at new Promise (<anonymous>)
    at Object.writeFile (/Users/shazron/Documents/git/work/adobe/aio-cli-plugin-app-dev/node_modules/universalify/index.js:7:14)
    at Dev.getOrGenerateCertificates (/Users/shazron/Documents/git/work/adobe/aio-cli-plugin-app-dev/src/commands/app/dev/index.js:222:16)
    at async Dev.runOneExtensionPoint (/Users/shazron/Documents/git/work/adobe/aio-cli-plugin-app-dev/src/commands/app/dev/index.js:169:33)
    at async Dev.run (/Users/shazron/Documents/git/work/adobe/aio-cli-plugin-app-dev/src/commands/app/dev/index.js:59:7)
    at async Dev._run (/Users/shazron/Documents/git/work/adobe/aio-cli-plugin-app-dev/node_modules/@oclif/core/lib/command.js:311:22) {
  code: 'ERR_INVALID_ARG_TYPE'
}
 ›   Error: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView.
 ›   Received an instance of Object
```

This is because of a typo here (note the previous line): 
https://github.com/adobe/aio-cli-plugin-app-dev/blob/b7dfd5c5a169c49ba4a2c2c2b85faa6a22d7f701/src/commands/app/dev/index.js#L238

The typo resulted in evaluation using the [comma operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comma_operator) -- the right most operand is returned.

This was not caught in the unit tests because we mock the return value.

## Workaround

```
aio config del aio-dev.dev-keys
rm -rf dist/dev-keys
aio app dev # will error
aio app dev # will not error
```
## How Has This Been Tested?

```
aio config del aio-dev.dev-keys
rm -rf dist/dev-keys
aio app dev # should not error
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
