### PR TITLE
Handle non-strings in createActionParametersFromRequest

### DIFF
--- a/src/lib/run-dev.js
+++ b/src/lib/run-dev.js
@@ -544,7 +544,11 @@ function createActionParametersFromRequest ({ req, contextItem, actionInputs = {
   // note we clone action so if env vars change between runs it is reflected - jm
   const action = { inputs: {} }
   Object.entries(actionInputs).forEach(([key, value]) => {
-    action.inputs[key] = interpolate(value, process.env)
+    if (typeof value === 'string') {
+      action.inputs[key] = interpolate(value, process.env)
+    } else {
+      action.inputs[key] = value
+    }
   })
 
   const params = {

--- a/test/lib/run-dev.test.js
+++ b/test/lib/run-dev.test.js
@@ -335,6 +335,50 @@ describe('createActionParametersFromRequest', () => {
     })
     delete process.env.mustache
   })
+
+  test('non-string inputs', async () => {
+    const req = createReq({
+      url: 'foo/bar',
+      body: { name: 'world' },
+      headers: {
+        'content-type': 'application/json'
+      }
+    })
+    const packageName = 'foo'
+    const action = {
+      function: fixturePath('actions/successReturnAction.js'),
+      inputs: {
+        someArray: ['hello', 'world'],
+        someBoolean: true,
+        someNumber: 42,
+        someObject: { hello: 'world' },
+        someString: 'hello world',
+      }
+    }
+    const actionName = 'a'
+    const actionConfig = {
+      [packageName]: {
+        actions: {
+          [actionName]: action
+        }
+      }
+    }
+    const actionRequestContext = { action, actionConfig, packageName, actionName }
+
+    const actionParams = await createActionParametersFromRequest({
+      req,
+      actionRequestContext,
+      actionInputs: action.inputs,
+      logger: mockLogger
+    })
+    expect(actionParams).toMatchObject({
+      someArray: ['hello', 'world'],
+      someBoolean: true,
+      someNumber: 42,
+      someObject: { hello: 'world' },
+      someString: 'hello world',
+    })
+  })
 })
 
 describe('isWebAction', () => {

--- a/test/lib/run-dev.test.js
+++ b/test/lib/run-dev.test.js
@@ -352,7 +352,7 @@ describe('createActionParametersFromRequest', () => {
         someBoolean: true,
         someNumber: 42,
         someObject: { hello: 'world' },
-        someString: 'hello world',
+        someString: 'hello world'
       }
     }
     const actionName = 'a'
@@ -376,7 +376,7 @@ describe('createActionParametersFromRequest', () => {
       someBoolean: true,
       someNumber: 42,
       someObject: { hello: 'world' },
-      someString: 'hello world',
+      someString: 'hello world'
     })
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix unhandled exception when `createActionParametersFromRequest` receives actionInputs values that are not strings, e.g.

```yaml
# ...
      actions:
        getStageAdobeCom:
          function: ../../.build/dx-excshell-1/packages/health/actions/getStageAdobeCom.js
          runtime: nodejs:18
          web: "yes"
          annotations:
            require-adobe-auth: false
            final: true
          inputs:
            <<: [*baseInputs, *ADOBE_KEYS]
            TIMEOUT_PER_CHECK: 10000
            urls:
              - https://blog.stage.adobe.com # blog
              - https://business.stage.adobe.com # bacom
              - https://business.stage.adobe.com/blog/ # bacom-blog
              - https://milo.stage.adobe.com # milo
              - https://www.stage.adobe.com/creativecloud.html # cc
              - https://www.stage.adobe.com/acrobat.html # dc
              - https://www.stage.adobe.com # homepage
```

This is a naive fix. Hypothetically we should handle interpolation of strings within array or object but it's Friday evening and my own use-case works now. I didn't even know interpolation like this was thing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
