### PR TITLE
Add package-level inputs when invoking actions

### DIFF
--- a/src/lib/run-dev.js
+++ b/src/lib/run-dev.js
@@ -470,7 +470,7 @@ async function serveWebAction (req, res, actionConfig, distFolder, actionLoader 
   const action = actionConfig[packageName]?.actions?.[contextItemName]
   const sequence = actionConfig[packageName]?.sequences?.[contextItemName]
   const owPath = restofPath.join('/')
-  const combinedInputs = { ... actionConfig?.[packageName]?.inputs, ... action?.inputs };
+  const combinedInputs = { ...actionConfig?.[packageName]?.inputs, ...action?.inputs }
 
   let invoker, contextItem
 

--- a/src/lib/run-dev.js
+++ b/src/lib/run-dev.js
@@ -273,6 +273,7 @@ async function invokeSequence ({ actionRequestContext, logger }) {
       : {
           __ow_headers: sequenceParams.__ow_headers,
           __ow_method: sequenceParams.__ow_method,
+          ...actionConfig?.[packageName]?.inputs,
           ...action?.inputs,
           ...lastActionResponse
         }
@@ -469,6 +470,7 @@ async function serveWebAction (req, res, actionConfig, distFolder, actionLoader 
   const action = actionConfig[packageName]?.actions?.[contextItemName]
   const sequence = actionConfig[packageName]?.sequences?.[contextItemName]
   const owPath = restofPath.join('/')
+  const combinedInputs = { ... actionConfig?.[packageName]?.inputs, ... action?.inputs };
 
   let invoker, contextItem
 
@@ -483,7 +485,7 @@ async function serveWebAction (req, res, actionConfig, distFolder, actionLoader 
   }
 
   const actionLogger = coreLogger(`serveWebAction ${contextItemName}`, { level: process.env.LOG_LEVEL, provider: 'winston' })
-  const contextItemParams = createActionParametersFromRequest({ req, contextItem, actionInputs: action?.inputs })
+  const contextItemParams = createActionParametersFromRequest({ req, contextItem, actionInputs: combinedInputs })
   contextItemParams.__ow_path = owPath
   actionLogger.debug('contextItemParams =', contextItemParams)
 

--- a/test/lib/run-dev.test.js
+++ b/test/lib/run-dev.test.js
@@ -633,6 +633,55 @@ describe('serveWebAction', () => {
     expect(mockLogger.warn).not.toHaveBeenCalled()
   })
 
+  test('action with package-level inputs', async () => {
+    const mockStatus = jest.fn()
+    const mockSend = jest.fn()
+
+    const res = createRes({ mockStatus, mockSend })
+    const req = createReq({ url: 'foo/bar' })
+    const packageName = 'foo'
+    const actionPath = fixturePath('actions/successNoReturnAction.js')
+    const actionLoader = () => {
+      return (params) => {
+        return {
+          body: params,
+        }
+      }
+    }
+
+    const actionConfig = {
+      [packageName]: {
+        inputs: {
+          packageInputB: 'input-b',
+          packageInputC: 'input-c',
+        },
+        actions: {
+          bar: {
+            function: actionPath,
+            web: true,
+            inputs: {
+              actionInputA: 'input-a',
+              packageInputC: 'input-c-override',
+            }
+          }
+        }
+      }
+    }
+
+    await serveWebAction(req, res, actionConfig, DIST_FOLDER, actionLoader)
+    expect(process.chdir).toHaveBeenCalledWith('dirname')
+    expect(mockSend).toHaveBeenCalledTimes(1)
+
+    // Validate inputs
+    const responseBody = mockSend.mock.calls[0][0];
+    expect(responseBody.actionInputA).toBe('input-a');
+    expect(responseBody.packageInputB).toBe('input-b');
+    expect(responseBody.packageInputC).toBe('input-c-override');
+
+    expect(mockStatus).toHaveBeenCalledWith(200)
+    expect(mockLogger.warn).not.toHaveBeenCalled()
+  })
+
   test('action found, is raw web action', async () => {
     const mimeType = 'multipart/form-data'
     const mockStatus = jest.fn()
@@ -856,6 +905,56 @@ describe('invokeSequence', () => {
       actionConfig
     }
     const response = await invokeSequence({ actionRequestContext, logger: mockLogger })
+    expect(response).toMatchObject({
+      body: '',
+      statusCode: 204
+    })
+  })
+
+  test('subsequent action in sequence receives package-level inputs', async () => {
+    const packageName = 'foo'
+    const actionPath = fixturePath('actions/successNoReturnAction.js')
+    
+    const mockAction = jest.fn();
+    mockAction.mockReturnValue(null);
+
+    const actionLoader = () => mockAction;
+
+    const sequence = { actions: 'a, b' }
+    const actionConfig = {
+      [packageName]: {
+        inputs: {
+          packageInputB: 'input-b',
+          packageInputC: 'input-c',
+        },
+        actions: {
+          a: { function: actionPath },
+          b: {
+            inputs: {
+              actionInputA: 'input-a',
+              packageInputC: 'input-c-override',
+            },
+            function: actionPath
+          }
+        }
+      }
+    }
+
+    const actionRequestContext = {
+      contextActionLoader: actionLoader,
+      contextItem: sequence,
+      contextItemParams: {},
+      packageName,
+      actionConfig
+    }
+    const response = await invokeSequence({ actionRequestContext, logger: mockLogger })
+    expect(mockAction).toHaveBeenCalledTimes(2);
+    
+    const params = mockAction.mock.calls[1][0];
+    expect(params.actionInputA).toBe('input-a');
+    expect(params.packageInputB).toBe('input-b');
+    expect(params.packageInputC).toBe('input-c-override');
+
     expect(response).toMatchObject({
       body: '',
       statusCode: 204

--- a/test/lib/run-dev.test.js
+++ b/test/lib/run-dev.test.js
@@ -644,7 +644,7 @@ describe('serveWebAction', () => {
     const actionLoader = () => {
       return (params) => {
         return {
-          body: params,
+          body: params
         }
       }
     }
@@ -653,7 +653,7 @@ describe('serveWebAction', () => {
       [packageName]: {
         inputs: {
           packageInputB: 'input-b',
-          packageInputC: 'input-c',
+          packageInputC: 'input-c'
         },
         actions: {
           bar: {
@@ -661,7 +661,7 @@ describe('serveWebAction', () => {
             web: true,
             inputs: {
               actionInputA: 'input-a',
-              packageInputC: 'input-c-override',
+              packageInputC: 'input-c-override'
             }
           }
         }
@@ -673,10 +673,10 @@ describe('serveWebAction', () => {
     expect(mockSend).toHaveBeenCalledTimes(1)
 
     // Validate inputs
-    const responseBody = mockSend.mock.calls[0][0];
-    expect(responseBody.actionInputA).toBe('input-a');
-    expect(responseBody.packageInputB).toBe('input-b');
-    expect(responseBody.packageInputC).toBe('input-c-override');
+    const responseBody = mockSend.mock.calls[0][0]
+    expect(responseBody.actionInputA).toBe('input-a')
+    expect(responseBody.packageInputB).toBe('input-b')
+    expect(responseBody.packageInputC).toBe('input-c-override')
 
     expect(mockStatus).toHaveBeenCalledWith(200)
     expect(mockLogger.warn).not.toHaveBeenCalled()
@@ -914,25 +914,25 @@ describe('invokeSequence', () => {
   test('subsequent action in sequence receives package-level inputs', async () => {
     const packageName = 'foo'
     const actionPath = fixturePath('actions/successNoReturnAction.js')
-    
-    const mockAction = jest.fn();
-    mockAction.mockReturnValue(null);
 
-    const actionLoader = () => mockAction;
+    const mockAction = jest.fn()
+    mockAction.mockReturnValue(null)
+
+    const actionLoader = () => mockAction
 
     const sequence = { actions: 'a, b' }
     const actionConfig = {
       [packageName]: {
         inputs: {
           packageInputB: 'input-b',
-          packageInputC: 'input-c',
+          packageInputC: 'input-c'
         },
         actions: {
           a: { function: actionPath },
           b: {
             inputs: {
               actionInputA: 'input-a',
-              packageInputC: 'input-c-override',
+              packageInputC: 'input-c-override'
             },
             function: actionPath
           }
@@ -948,12 +948,12 @@ describe('invokeSequence', () => {
       actionConfig
     }
     const response = await invokeSequence({ actionRequestContext, logger: mockLogger })
-    expect(mockAction).toHaveBeenCalledTimes(2);
-    
-    const params = mockAction.mock.calls[1][0];
-    expect(params.actionInputA).toBe('input-a');
-    expect(params.packageInputB).toBe('input-b');
-    expect(params.packageInputC).toBe('input-c-override');
+    expect(mockAction).toHaveBeenCalledTimes(2)
+
+    const params = mockAction.mock.calls[1][0]
+    expect(params.actionInputA).toBe('input-a')
+    expect(params.packageInputB).toBe('input-b')
+    expect(params.packageInputC).toBe('input-c-override')
 
     expect(response).toMatchObject({
       body: '',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds package-level inputs to the action execution context.

## Related Issue

Fix #135 

## Motivation and Context

Actions should receive both action and package-level input variables.

## How Has This Been Tested?

Added unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
