### PR TITLE
Add AIO_DEV env flag to detect running local

### DIFF
--- a/src/lib/run-dev.js
+++ b/src/lib/run-dev.js
@@ -84,7 +84,7 @@ async function runDev (runOptions, config, _inprocHookRunner) {
   // set up environment variables for aio
   // this can be read as truthy, it will not exist in Runtime
   // console.log('AIO_DEV ', process.env.AIO_DEV ? 'dev' : 'prod')
-  process.env.AIO_DEV = true
+  process.env.AIO_DEV = 'true'
 
   const serverPortToUse = parseInt(process.env.PORT) || SERVER_DEFAULT_PORT
   const serverPort = await getPort({ port: serverPortToUse })

--- a/src/lib/run-dev.js
+++ b/src/lib/run-dev.js
@@ -81,6 +81,10 @@ async function runDev (runOptions, config, _inprocHookRunner) {
   process.env.__OW_API_KEY = process.env.AIO_RUNTIME_AUTH
   process.env.__OW_NAMESPACE = process.env.AIO_RUNTIME_NAMESPACE
   process.env.__OW_API_HOST = process.env.AIO_RUNTIME_APIHOST
+  // set up environment variables for aio
+  // this can be read as truthy, it will not exist in Runtime
+  // console.log('AIO_DEV ', process.env.AIO_DEV ? 'dev' : 'prod')
+  process.env.AIO_DEV = true
 
   const serverPortToUse = parseInt(process.env.PORT) || SERVER_DEFAULT_PORT
   const serverPort = await getPort({ port: serverPortToUse })

--- a/src/lib/run-dev.js
+++ b/src/lib/run-dev.js
@@ -83,7 +83,7 @@ async function runDev (runOptions, config, _inprocHookRunner) {
   process.env.__OW_API_HOST = process.env.AIO_RUNTIME_APIHOST
   // set up environment variables for aio
   // this can be read as truthy, it will not exist in Runtime
-  // console.log('AIO_DEV ', process.env.AIO_DEV ? 'dev' : 'prod')
+  // ex. console.log('AIO_DEV ', process.env.AIO_DEV ? 'dev' : 'prod')
   process.env.AIO_DEV = 'true'
 
   const serverPortToUse = parseInt(process.env.PORT) || SERVER_DEFAULT_PORT


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Inject env var to detect if we were run by `aio app dev`
this can be read as truthy, it will not exist in Runtime (ie. `aio app run` )
  
    console.log('AIO_DEV ', process.env.AIO_DEV ? 'dev' : 'prod')

## Related Issue

https://github.com/adobe/aio-cli/issues/753


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
