### PR TITLE
feat: fixed the issue where unmapped action input params show up as literal placeholders

### DIFF
--- a/src/lib/run-dev.js
+++ b/src/lib/run-dev.js
@@ -545,7 +545,10 @@ function interpolate (valueString, props) {
   // replace ${VAR_NAME}, $VAR_NAME, or {VAR_NAME} with values from props, but not if they are enclosed in quotes
   // if key is not found on props, the value is returned as is (no replacement)
   const retStr = valueString.replace(/(?<!['"`])\$\{(\w+)\}(?!['"`])|(?<!['"`])\$(\w+)(?!['"`])|(?<!['"`])\{(\w+)\}(?!['"`])/g,
-    (_, varName1, varName2, varName3) => props[varName1 || varName2 || varName3] || _)
+    (_, varName1, varName2, varName3) => {
+      const varName = varName1 || varName2 || varName3
+      return Object.prototype.hasOwnProperty.call(props, varName) ? props[varName] : ''
+    })
   return retStr
 }
 

--- a/test/lib/run-dev.test.js
+++ b/test/lib/run-dev.test.js
@@ -348,7 +348,7 @@ describe('createActionParametersFromRequest', () => {
       justDollar: 'value is world',
       mustache: 'value is world',
       literal: 'value is literally "${mustache}" and "{mustache}"',
-      doesNotExist: 'value is ${doesNotExist}'
+      doesNotExist: 'value is '
     })
     delete process.env.mustache
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It turns out that  during aio app dev, any input param whose value is left as literal placeholders like for example `$<MY_FIRSTINPUT>` ends up being injected verbatim in the environment instead of being skipped if it is not mapped in the process env

Fix:
 
To align with the expectation that an undefined env variable should result in a empty string for the action input, the `interpolate` function was modified so that the it would now check if the property exists in the process.env and if not, it returns an empty string

## Related Issue

[ACNA-3846](https://jira.corp.adobe.com/browse/ACNA-3846)
Original git hub issue [here]( https://github.com/adobe/aio-cli/issues/750) 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

It turns out that  during aio app dev, any input param whose value is left as literal placeholders like for example `${FIRST_INPUT}, $SECOND_INPUT, or {THIRD_INPUT}` end up being injected verbatim in the environment instead of being skipped if it is not mapped in the process env

## How Has This Been Tested?

- Locally linked the plugin - `aio plugins link .`
- Made the appropriate change to the app.config.yaml file for an action ( as described in the bug) and make sure that the variable is not defined in the process env
- Once built, invoke the action  and verify that instead of the literal placeholder value is returned, an empty string is returned
- If the value is set in the env, that will be used. 
- Verified that the all the tests are passing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
