### PR TITLE
fix: add secrets: inherit to reusable workflows

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -8,4 +8,5 @@ on:
 jobs:
   build:
     uses: adobe/aio-reusable-workflows/.github/workflows/daily.yml@main
+    secrets: inherit
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -19,3 +19,4 @@ on:
 jobs:
   checkout:
     uses: adobe/aio-reusable-workflows/.github/workflows/prerelease.yml@main
+    secrets: inherit

--- a/.github/workflows/version-bump-publish.yml
+++ b/.github/workflows/version-bump-publish.yml
@@ -15,3 +15,4 @@ on:
 jobs:
   checkout:
     uses: adobe/aio-reusable-workflows/.github/workflows/version-bump-publish.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Add `secrets: inherit` to the daily, prerelease, and version-bump-publish reusable workflow jobs so repository secrets are passed through to `adobe/aio-reusable-workflows`

## Test plan
- [ ] Verify the daily workflow runs successfully with secrets available
- [ ] Verify the prerelease workflow runs successfully with secrets available
- [ ] Verify the version-bump-publish workflow runs successfully with secrets available

🤖 Generated with [Claude Code](https://claude.com/claude-code)