### PR TITLE
feat: support loading actions in esm environments

### DIFF
--- a/src/lib/run-dev.js
+++ b/src/lib/run-dev.js
@@ -14,6 +14,7 @@ const cloneDeep = require('lodash.clonedeep')
 const express = require('express')
 const fs = require('fs-extra')
 const path = require('node:path')
+const fsp = require('node:fs/promises')
 const https = require('node:https')
 const crypto = require('node:crypto')
 const livereload = require('livereload')
@@ -316,9 +317,25 @@ async function invokeSequence ({ actionRequestContext, logger }) {
  * @returns {object} the action function
  */
 async function defaultActionLoader ({ distFolder, packageName, actionName }) {
-  const actionFolder = path.join(distFolder, packageName, actionName)
-  const actionPath = `${actionFolder}-temp/index.js`
-  delete require.cache[actionPath]
+  const actionTempDir = path.join(distFolder, packageName, `${actionName}-temp`)
+  const actionPath = path.join(actionTempDir, 'index.js')
+
+  // Bundled actions are CommonJS. If an ancestor app package.json has "type": "module",
+  // Node would treat index.js here as ESM unless this directory declares otherwise.
+  try {
+    await fsp.access(actionPath)
+  } catch {
+    return require(actionPath)?.main
+  }
+
+  await fsp.writeFile(path.join(actionTempDir, 'package.json'), '{"type":"commonjs"}', 'utf8')
+
+  try {
+    delete require.cache[require.resolve(actionPath)]
+  } catch {
+    // ignore: module not yet loaded
+  }
+
   return require(actionPath)?.main
 }
 

--- a/test/__fixtures__/dist/my-package/successReturnAction-temp/package.json
+++ b/test/__fixtures__/dist/my-package/successReturnAction-temp/package.json
@@ -1,0 +1,1 @@
+{"type":"commonjs"}


### PR DESCRIPTION
## Description

Fixes an issue where projects that have `type: "module"` in their `package.json` cannot serve actions locally via `aio app dev` due to the loader expecting esm.

This fix dynamically adds a `package.json` whose contents are `{"type":"commonjs"}` next to the dist action to denote it as commonjs for the loader.

tested on this app:
https://github.com/adobe/appbuilder-quickstarts/tree/master/typescript-app

## Related Issue

https://jira.corp.adobe.com/browse/IOEXT-1726

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

coverage maintained.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
